### PR TITLE
Make awake_sleep_seconds optional and support None

### DIFF
--- a/garth/data/sleep.py
+++ b/garth/data/sleep.py
@@ -47,9 +47,9 @@ class DailySleepDTO:
     deep_sleep_seconds: int
     light_sleep_seconds: int
     rem_sleep_seconds: int
-    awake_sleep_seconds: int
     device_rem_capable: bool
     retro: bool
+    awake_sleep_seconds: Optional[int] = None
     sleep_from_device: Optional[bool] = None
     sleep_version: Optional[int] = None
     awake_count: Optional[int] = None


### PR DESCRIPTION
I have some days in my Garmin Sleep data where I have no restless moments sleeping this results in an error daily_sleep_dto.awake_sleep_seconds
  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]